### PR TITLE
Define workflow to build and push docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - '*'
     tags:
       - 'v*'
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,38 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+      - '*'
+    tags:
+      - 'v*'
+
+env:
+  DOCKER_IMAGE_BASENAME: qwantresearch/fafnir
+
+jobs:
+  build_docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get image name
+        run: |
+          VERSION=${GITHUB_REF#refs/*/}
+          if [ "$VERSION" == "master" ]; then
+            IMAGE_TAG=latest
+          else
+            IMAGE_TAG=$VERSION
+          fi
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE_BASENAME:$IMAGE_TAG" >> $GITHUB_ENV
+
+      - run: docker build --label "org.label-schema.vcs-ref=$GITHUB_SHA" -t $DOCKER_IMAGE .
+
+      - run: docker push $DOCKER_IMAGE

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Fafnir CI
 on: [push, pull_request]
 
 jobs:
-  build:
+  tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This workflow replaces the deprecated DockerHub integration that was defined on the previous QwantResearch repository.