### PR TITLE
Add 'cuisine' tag values in 'poi_type.name' used for filtered queries

### DIFF
--- a/tests/fafnir_tests/data/data.sql
+++ b/tests/fafnir_tests/data/data.sql
@@ -23,7 +23,8 @@ INSERT INTO osm_poi_point (
             "name:ru" => "студия океана",
             "name:it" => "Oceano Studioso",
             "name_int" => "Ocean Studio",
-            "name:latin" => "Ocean Studio"
+            "name:latin" => "Ocean Studio",
+            "cuisine" => "japanese;coffee_shop"
         '
     ),
     -- POI located at lon=2, lat=2

--- a/tests/fafnir_tests/mod.rs
+++ b/tests/fafnir_tests/mod.rs
@@ -185,7 +185,10 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
     assert_eq!(label_ocean_poi, &"Ocean Studio (bob's town)");
     // Test poi_type
     let poi_type_ocean_poi = &ocean_poi.poi_type.name;
-    assert_eq!(poi_type_ocean_poi, &"class_cafe subclass_cafe");
+    assert_eq!(
+        poi_type_ocean_poi,
+        &"class_cafe subclass_cafe cuisine:japanese cuisine:coffee_shop"
+    );
 
     // Test Properties: the amenity property for this POI should be "cafe"
     let properties_ocean_poi = &ocean_poi.properties;
@@ -348,8 +351,13 @@ pub fn main_test(mut es_wrapper: ElasticSearchWrapper, pg_wrapper: PostgresWrapp
     // Test existance of water POIs
     let res = es_wrapper.search_and_filter("name:(Fontaine-Lavoir Saint-Guimond)", |_| true);
     assert_eq!(res.count(), 1);
-
     let res = es_wrapper.search_and_filter("name:(Baie du Mont Saint-Michel)", |_| true);
+    assert_eq!(res.count(), 1);
+
+    // Filter by poi_type.name
+    let res = es_wrapper.search_and_filter("poi_type.name:(subclass_cafe)", |_| true);
+    assert_eq!(res.count(), 2);
+    let res = es_wrapper.search_and_filter("poi_type.name:(cuisine\\:coffee_shop)", |_| true);
     assert_eq!(res.count(), 1);
 }
 


### PR DESCRIPTION
The field `poi_type.name` (defined [in Mimirsbrunn](https://github.com/CanalTP/mimirsbrunn/blob/v1.21.0/config/poi_settings.json#L206)) is already exploited to index the "class" and "subclass". Then, the words can be used in filtered queries in Idunn, to look for POIs with a specific class or subclass.

This PR suggests to use the same mechanism to index additional tags: only "cuisine" for now.

It's quite hackish :confused:.  A saner approach in the future would be to use the ["flattened" field type](https://www.elastic.co/guide/en/elasticsearch/reference/master/flattened.html) (available in recent versions of Elasticsearch) to index/search arbitrary tags.