### PR TITLE
update to latest mimir with force merge flag and struct container config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "async-graphql-value",
  "async-stream",
  "async-trait",
- "bytes 1.0.1",
+ "bytes",
  "chrono",
  "fnv",
  "futures-util",
@@ -213,7 +213,7 @@ version = "2.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f81c53f8668d6e2634b78e72b0e0d870bdde702a911a3ce24c30981c1be48e1"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "indexmap",
  "serde",
  "serde_json",
@@ -323,18 +323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,7 +360,7 @@ checksum = "a4a3f238d4b66f33d9162893ade03cd8a485320f591b244ea5b7f236d3494e98"
 dependencies = [
  "base64 0.13.0",
  "bollard-stubs",
- "bytes 1.0.1",
+ "bytes",
  "chrono",
  "dirs-next",
  "futures-core",
@@ -444,16 +432,6 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
-name = "bytes"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-dependencies = [
- "byteorder",
- "iovec",
-]
 
 [[package]]
 name = "bytes"
@@ -539,8 +517,8 @@ dependencies = [
 
 [[package]]
 name = "common"
-version = "0.1.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#e512e92b6d58e65a9e37654249a6f7cd3638be0c"
+version = "1.0.0-rc1"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=b3c5143e#b3c5143edc5f290cbdb1686bb73069c073c6d5c8"
 dependencies = [
  "config",
  "serde",
@@ -550,7 +528,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.11.0"
-source = "git+https://github.com/mehcode/config-rs.git?branch=master#3f179990e1cca46f9b3d82e676a4a01d5314052e"
+source = "git+https://github.com/mehcode/config-rs.git?branch=master#6de19be2b5be7aa16b697c2587a04445c47defba"
 dependencies = [
  "async-trait",
  "lazy_static",
@@ -864,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d853e1c104dbad916425c88e72ac5b73db65bbc22d3b8ab945174e68df91e6f0"
 dependencies = [
  "base64 0.11.0",
- "bytes 1.0.1",
+ "bytes",
  "dyn-clone",
  "lazy_static",
  "percent-encoding",
@@ -936,13 +914,12 @@ version = "0.3.12"
 dependencies = [
  "approx 0.5.0",
  "async-compression",
- "config",
  "cosmogony",
  "elasticsearch",
  "futures 0.3.16",
  "geo-types 0.7.2",
  "itertools 0.9.0",
- "mimir2",
+ "mimir",
  "mimirsbrunn",
  "num_cpus",
  "once_cell",
@@ -1012,10 +989,8 @@ checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if",
  "crc32fast",
- "futures 0.1.31",
  "libc",
  "miniz_oxide",
- "tokio-io",
 ]
 
 [[package]]
@@ -1048,12 +1023,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -1334,7 +1303,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1395,7 +1364,7 @@ checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "bytes 1.0.1",
+ "bytes",
  "headers-core",
  "http",
  "mime",
@@ -1464,7 +1433,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1475,7 +1444,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
  "pin-project-lite",
 ]
@@ -1513,7 +1482,7 @@ version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1537,7 +1506,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "hyper",
  "native-tls",
  "tokio",
@@ -1615,7 +1584,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
 ]
 
 [[package]]
@@ -1625,15 +1594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1667,6 +1627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,19 +1661,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "libc"
@@ -1797,9 +1753,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimir2"
-version = "0.1.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#e512e92b6d58e65a9e37654249a6f7cd3638be0c"
+name = "mimir"
+version = "1.0.0-rc1"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=b3c5143e#b3c5143edc5f290cbdb1686bb73069c073c6d5c8"
 dependencies = [
  "async-graphql",
  "async-graphql-warp",
@@ -1824,6 +1780,7 @@ dependencies = [
  "serde_qs",
  "snafu",
  "tokio",
+ "tokio-stream",
  "toml",
  "tracing",
  "tracing-appender",
@@ -1836,10 +1793,11 @@ dependencies = [
 
 [[package]]
 name = "mimirsbrunn"
-version = "1.24.0-alpha"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#e512e92b6d58e65a9e37654249a6f7cd3638be0c"
+version = "2.0.0-rc1"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=b3c5143e#b3c5143edc5f290cbdb1686bb73069c073c6d5c8"
 dependencies = [
  "address-formatter",
+ "async-compression",
  "bincode",
  "chrono",
  "chrono-tz",
@@ -1850,17 +1808,16 @@ dependencies = [
  "csv",
  "csv-async",
  "failure",
- "flate2",
  "futures 0.3.16",
  "geo 0.18.0",
  "geo-types 0.7.2",
  "http",
  "human-sort",
- "itertools 0.9.0",
+ "itertools 0.10.1",
  "json",
  "lazy_static",
  "log",
- "mimir2",
+ "mimir",
  "navitia-poi-model",
  "num_cpus",
  "osm_boundaries_utils",
@@ -1920,6 +1877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,7 +1920,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "408327e2999b839cd1af003fc01b2019a6c10a1361769542203f6fedc5179680"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
  "futures-util",
  "http",
@@ -2021,14 +1984,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -2349,8 +2310,8 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "places"
-version = "0.1.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git#e512e92b6d58e65a9e37654249a6f7cd3638be0c"
+version = "1.0.0-rc1"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=b3c5143e#b3c5143edc5f290cbdb1686bb73069c073c6d5c8"
 dependencies = [
  "chrono-tz",
  "common",
@@ -2374,7 +2335,7 @@ checksum = "ff3e0f70d32e20923cabf2df02913be7c1842d4c772db8065c00fcfdd1d1bff3"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "fallible-iterator",
  "hmac",
  "md-5",
@@ -2390,7 +2351,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "430f4131e1b7657b0cd9a2b0c3408d77c9a43a042d300b8c77f981dffcc43a2f"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fallible-iterator",
  "postgres-protocol",
 ]
@@ -2573,12 +2534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2743,7 +2698,7 @@ checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "async-compression",
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3284,12 +3239,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,7 +3331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
  "mio",
@@ -3392,17 +3341,6 @@ dependencies = [
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
-]
-
-[[package]]
-name = "tokio-io"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
-dependencies = [
- "bytes 0.4.12",
- "futures 0.1.31",
- "log",
 ]
 
 [[package]]
@@ -3434,7 +3372,7 @@ checksum = "2d2b1383c7e4fb9a09e292c7c6afb7da54418d53b045f1c1fac7a911411a2b8b"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "fallible-iterator",
  "futures 0.3.16",
  "log",
@@ -3479,7 +3417,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
@@ -3504,9 +3442,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if",
  "log",
@@ -3528,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -3556,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -3669,7 +3607,7 @@ checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "http",
  "httparse",
  "input_buffer",
@@ -3856,7 +3794,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures 0.3.16",
  "headers",
  "http",
@@ -4019,12 +3957,6 @@ dependencies = [
  "num-traits",
  "thiserror",
 ]
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,9 @@ tracing-futures = "0.2"
 tracing = { version = "0.1", default_features = false, features = ["release_max_level_info"] }
 url = { version = "2", features = ["serde"] }
 
-# Mimirsbrunn dependancies
-# requires higher `size` in search_documents
-mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
-mimir2 = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
-places = { git = "https://github.com/CanalTP/mimirsbrunn.git" }
-
-[dependencies.config]
-git = "https://github.com/mehcode/config-rs.git"
-branch = "master"
-default_features = false
+mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "b3c5143e" }
+mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "b3c5143e" }
+places = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "b3c5143e" }
 
 [dev-dependencies]
 cosmogony = "0.10.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
 
 RUN npm install -g bunyan
 RUN echo "#!/bin/bash"                                   >> /usr/bin/bunyan_formated
+RUN echo "set -o pipefail"                               >> /usr/bin/bunyan_formated
 RUN echo "CMD=\$1; shift; ARG=\$@"                       >> /usr/bin/bunyan_formated
 RUN echo "\$CMD --config-dir /etc/fafnir \$ARG | bunyan" >> /usr/bin/bunyan_formated
 RUN chmod +x /usr/bin/bunyan_formated

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM debian:buster-slim
 WORKDIR /srv
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV RUST_LOG "tracing=info,mimir2=info,fafnir=info"
+ENV RUST_LOG "tracing=info,mimir=info,fafnir=info"
 
 RUN apt-get update \
     && apt-get install -y libcurl4 sqlite3 npm \

--- a/config/elasticsearch/default.toml
+++ b/config/elasticsearch/default.toml
@@ -1,20 +1,33 @@
 [elasticsearch]
-url = "http://localhost:9200"
+  url = "http://localhost:9200"
 
-# Timeout in milliseconds on client calls to Elasticsearch.
-timeout = 5000
+  # Timeout in milliseconds on client calls to Elasticsearch.
+  timeout = 5000
 
-# Constraint on the version of Elasticsearch.
-version_req = ">=7.13.0"
+  # Constraint on the version of Elasticsearch.
+  version_req = ">=7.13.0"
 
-# Number of documents loaded per request when performing a `list_documents`
-scroll_chunk_size = 1000
+  # Number of documents loaded per request when performing a `list_documents`
+  scroll_chunk_size = 1000
 
-# Liveness of the PIT while performing a `list_documents`.
-scroll_pit_alive = "1m"
+  # Liveness of the PIT while performing a `list_documents`.
+  scroll_pit_alive = "1m"
 
-# Max of concurrent requests during insertion.
-insertion_concurrent_requests = 8
+  # Max of concurrent requests during insertion.
+  insertion_concurrent_requests = 8
 
-# Number of document per request during insertion.
-insertion_chunk_size = 100
+  # Number of document per request during insertion.
+  insertion_chunk_size = 100
+
+  # Number of shards copies that must be active before performing indexing
+  # operations.
+  wait_for_active_shards = 1
+
+[elasticsearch.force_merge]
+  # If this is set to `true` a force merge will be performed after an index
+  # is published. For more details see
+  # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
+  enabled = true
+
+  # Number of segments to merge to.
+  max_number_segments = 1

--- a/config/fafnir/default.toml
+++ b/config/fafnir/default.toml
@@ -33,12 +33,18 @@
 
 # Container configuration for searchable POIs.
 [container-search]
+  name = "poi"
   dataset = "default"
+  visibility = "public"
 
 # Container configuration for non-searchable POIs.
 [container-nosearch]
+  name = "poi"
   dataset = "nosearch"
+  visibility = "private"
 
 # Container configuration for tripadvisor2mimir.
 [container-tripadvisor]
+  name = "poi"
   dataset = "tripadvisor"
+  visibility = "private"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
-use config::Config;
 use futures::Future;
-use mimir2::common::config::config_from;
+use mimir::common::config::config_from;
 use mimirsbrunn::utils::logger::logger_init;
 use serde::de::DeserializeOwned;
 use structopt::StructOpt;
@@ -26,7 +25,7 @@ struct Args {
     pub settings: Vec<String>,
 }
 
-pub async fn run<S: DeserializeOwned, R: Future>(f: impl FnOnce(S, Config) -> R) -> R::Output {
+pub async fn run<S: DeserializeOwned, R: Future>(f: impl FnOnce(S) -> R) -> R::Output {
     let args = Args::from_args();
 
     let raw_config = config_from(
@@ -56,5 +55,5 @@ pub async fn run<S: DeserializeOwned, R: Future>(f: impl FnOnce(S, Config) -> R)
         .expect("could not serialize config"),
     );
 
-    f(settings, raw_config).await
+    f(settings).await
 }

--- a/src/mimir.rs
+++ b/src/mimir.rs
@@ -1,19 +1,14 @@
 //! Utilities arround common mimir operations.
 
-use config::Config;
 use elasticsearch::Elasticsearch;
 use futures::join;
-use futures::stream::{Stream, StreamExt};
+use futures::stream::StreamExt;
 use places::admin::Admin;
 
-use mimir2::common::document::ContainerDocument;
-use mimir2::domain::model::index::IndexVisibility;
-use mimir2::domain::ports::primary::generate_index::GenerateIndex;
-use mimir2::domain::ports::primary::list_documents::ListDocuments;
+use mimir::domain::ports::primary::list_documents::ListDocuments;
 use mimirsbrunn::admin_geofinder::AdminGeoFinder;
 
 use crate::utils::get_index_creation_date;
-use crate::Error;
 
 /// Prefix to ES index names for mimirsbrunn
 pub const MIMIR_PREFIX: &str = "munin";
@@ -40,26 +35,4 @@ pub async fn build_admin_geofinder<G: ListDocuments<Admin>>(mimir: &G) -> AdminG
         .map(|admin| admin.expect("could not parse admin"))
         .collect()
         .await
-}
-
-pub async fn create_index<G: GenerateIndex, D: ContainerDocument + Send + Sync + 'static>(
-    mimir: &G,
-    config: &Config,
-    dataset: &str,
-    visibility: IndexVisibility,
-    documents: impl Stream<Item = D> + Send + Sync + 'static,
-) -> Result<(), Error> {
-    let index_config = Config::builder()
-        .add_source(D::default_es_container_config())
-        .add_source(config.clone())
-        .set_override("container.dataset", dataset.to_string())
-        .expect("failed to create config key container.dataset")
-        .build()
-        .expect("could not build search config");
-
-    mimir
-        .generate_index(index_config, documents, visibility)
-        .await?;
-
-    Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,8 +17,3 @@ pub struct FafnirSettings {
 pub struct PostgresSettings {
     pub url: String,
 }
-
-#[derive(Debug, Deserialize)]
-pub struct ContainerConfig {
-    pub dataset: String,
-}


### PR DESCRIPTION
Update to latest mimirsbrunn.

Most noticeable changes:

 - `mimir2` was renamed into `mimir`
 - https://github.com/CanalTP/mimirsbrunn/pull/630, this also means we don't need to pass anything to mimir through `config::Config` anymore :tada: