### PR TITLE
TripAdvisor: parser optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ places = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "b3c5143e" 
 cosmogony = "0.10.3"
 serde_derive = "1"
 approx = "0.5.0"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1

--- a/src/sources/tripadvisor/mod.rs
+++ b/src/sources/tripadvisor/mod.rs
@@ -34,10 +34,7 @@ pub fn read_pois(
                     chunk
                         .into_iter()
                         .map(|raw| {
-                            let raw_utf8 =
-                                String::from_utf8(raw).expect("invalid UTF-8 for property");
-
-                            let property = quick_xml::de::from_str(&raw_utf8)
+                            let property = quick_xml::de::from_reader(raw.as_slice())
                                 .expect("failed to parse property");
 
                             convert::build_poi(property, geofinder.as_ref())

--- a/src/sources/tripadvisor/mod.rs
+++ b/src/sources/tripadvisor/mod.rs
@@ -34,8 +34,11 @@ pub fn read_pois(
                     chunk
                         .into_iter()
                         .map(|raw| {
-                            let property =
-                                quick_xml::de::from_str(&raw).expect("failed to parse properties");
+                            let raw_utf8 =
+                                String::from_utf8(raw).expect("invalid UTF-8 for property");
+
+                            let property = quick_xml::de::from_str(&raw_utf8)
+                                .expect("failed to parse property");
 
                             convert::build_poi(property, geofinder.as_ref())
                         })

--- a/src/sources/tripadvisor/parse.rs
+++ b/src/sources/tripadvisor/parse.rs
@@ -30,6 +30,8 @@ pub fn split_raw_properties(input: impl AsyncBufRead + Unpin) -> impl Stream<Ite
         {
             // The first line may contain some extra XML informations
             if first_line {
+                first_line = false;
+
                 let token_start = {
                     if let Some(start) = buffer.find(START_TOKEN) {
                         start
@@ -40,10 +42,8 @@ pub fn split_raw_properties(input: impl AsyncBufRead + Unpin) -> impl Stream<Ite
 
                 if token_start > 0 {
                     debug!("Ignored begining of file: {}", &buffer[..token_start]);
+                    buffer = buffer[token_start..].to_string();
                 }
-
-                first_line = false;
-                buffer = buffer[token_start..].to_string();
             }
 
             if buffer.ends_with(END_TOKEN) {


### PR DESCRIPTION
So ... During my lunch break I was investigating on why using directly [`reader.read_line(&mut buffer)`](https://docs.rs/tokio/1.8.4/tokio/io/trait.AsyncBufReadExt.html#method.read_line) instead of appending with an allocated string from [`LinesStream`](https://docs.rs/tokio-stream/0.1.8/tokio_stream/wrappers/struct.LinesStream.html) was actually slower (and not in all cases as it was faster with the photos feed but slower on regular property list). Flamegraph showed that what was taking the most amount of time in *read_line* version was UTF-8 validation, so my best bet is that in the specific case of this patch, only for the indexing of property list, some compiler optimizations were not triggered :shrug: 

With that new information I couldn't resist to attempt some optimizations:

 - keep the rewritten `split_raw_properties` with fewer copies and allocations (these operations are actually non negligible according to perf)
 - delegate UTF-8 validation to parallel threads which are already doing XML validation / parsing
 - double the number of parallel threads (main thread has now a lower load while others have more work to do, so we needed to balance things a bit)
 - enable aggressive link-time optimizations, this means that it takes much more time to compile in release mode, but I think this is a reasonable compromise as this is the job we wait for on our dev workflows

With these optimizations enabled on #71 (with photos import), the imports takes about 9 minute instead of 14 when uploading from my personal computer to dev's Elasticsearch (with Liechtenstein admins loaded), which is a 50% improvement! :tada: 

**TLDR**: I think we can say that we make Rust's community proud and that our importer can be considered to be :sparkles:blazingly fast:sparkles:, especially considering that a plain gzip decompression using `zcat PropertyList.xml.gz > /dev/null` takes 8 minutes and `zcat PropertyList.xml.gz | rg '<Property ' | wc -l` takes 10 minutes while performing a subset of what we do.

**PS**: sorry about the long text, don't feel obliged to read everything if you happen to read it backward and see this first :stuck_out_tongue_winking_eye: 