### PR TITLE
tripadvisor2mimir: add common values to properties

### DIFF
--- a/src/bin/tripadvisor2mimir.rs
+++ b/src/bin/tripadvisor2mimir.rs
@@ -17,7 +17,6 @@ use tokio::fs::File;
 use tokio::io::{AsyncBufRead, BufReader};
 use tracing::info;
 
-use fafnir::settings::FafnirSettings;
 use fafnir::sources::tripadvisor::{read_photos, read_pois};
 
 /// Buffer size use for IO over XML files
@@ -33,7 +32,6 @@ struct TripAdvisorSettings {
 #[serde(rename_all = "kebab-case")]
 struct Settings {
     tripadvisor: TripAdvisorSettings,
-    fafnir: FafnirSettings,
     elasticsearch: ElasticsearchStorageConfig,
     container_tripadvisor: ContainerConfig,
 }

--- a/src/sources/tripadvisor/pois/convert.rs
+++ b/src/sources/tripadvisor/pois/convert.rs
@@ -146,7 +146,10 @@ pub fn build_poi(property: Property, geofinder: &AdminGeoFinder) -> Result<(u32,
     };
 
     let properties = [
+        ("name", Some(name.clone())),
         ("website", property.url),
+        ("poi_class", Some(category)),
+        ("poi_subclass", Some(sub_category)),
         ("ta:url", property.ta_url),
         ("ta:photos_url", property.ta_photos_url),
         ("ta:review_count", Some(property.review_count.to_string())),
@@ -157,6 +160,11 @@ pub fn build_poi(property: Property, geofinder: &AdminGeoFinder) -> Result<(u32,
     ]
     .into_iter()
     .filter_map(|(key, val)| Some((key.to_string(), val?)))
+    .chain(
+        (names.0)
+            .iter()
+            .map(|prop| (format!("name:{}", prop.key), prop.value.clone())),
+    )
     .collect();
 
     Ok((


### PR DESCRIPTION
This will help Idunn which reads most of the data from the properties instead of reading other fields, which were usually specific to openmaptiles.