### PR TITLE
lazy_es: implement an exponential backoff for the msearch handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=fd067a3#fd067a328d69e7a8b5f13eef2891c79314c067f2"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
 dependencies = [
  "config",
  "serde",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "mimir"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=fd067a3#fd067a328d69e7a8b5f13eef2891c79314c067f2"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
 dependencies = [
  "async-trait",
  "bollard",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "mimirsbrunn"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=fd067a3#fd067a328d69e7a8b5f13eef2891c79314c067f2"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
 dependencies = [
  "address-formatter",
  "anyhow",
@@ -2006,7 +2006,7 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 [[package]]
 name = "places"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=fd067a3#fd067a328d69e7a8b5f13eef2891c79314c067f2"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
 dependencies = [
  "chrono-tz",
  "common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=73f368b#73f368bc72fb0cfacd1b14b9c823af69a5524291"
 dependencies = [
  "config",
  "serde",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "mimir"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=73f368b#73f368bc72fb0cfacd1b14b9c823af69a5524291"
 dependencies = [
  "async-trait",
  "bollard",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "mimirsbrunn"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=73f368b#73f368bc72fb0cfacd1b14b9c823af69a5524291"
 dependencies = [
  "address-formatter",
  "anyhow",
@@ -2006,7 +2006,7 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 [[package]]
 name = "places"
 version = "2.5.0"
-source = "git+https://github.com/CanalTP/mimirsbrunn.git?branch=bulk-backoff#33b66c0f739b226516aecb08ae9a7d4588618447"
+source = "git+https://github.com/CanalTP/mimirsbrunn.git?rev=73f368b#73f368bc72fb0cfacd1b14b9c823af69a5524291"
 dependencies = [
  "chrono-tz",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ tracing-futures = "0.2"
 tracing = { version = "0.1", default_features = false, features = ["release_max_level_info"] }
 url = { version = "2", features = ["serde"] }
 
-mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git", branch = "bulk-backoff" }
-mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git", branch = "bulk-backoff" }
-places = { git = "https://github.com/CanalTP/mimirsbrunn.git", branch = "bulk-backoff" }
+mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "73f368b" }
+mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "73f368b" }
+places = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "73f368b" }
 
 [dev-dependencies]
 cosmogony = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ tracing-futures = "0.2"
 tracing = { version = "0.1", default_features = false, features = ["release_max_level_info"] }
 url = { version = "2", features = ["serde"] }
 
-mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "fd067a3" }
-mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "fd067a3" }
-places = { git = "https://github.com/CanalTP/mimirsbrunn.git", rev = "fd067a3" }
+mimirsbrunn = { git = "https://github.com/CanalTP/mimirsbrunn.git", branch = "bulk-backoff" }
+mimir = { git = "https://github.com/CanalTP/mimirsbrunn.git", branch = "bulk-backoff" }
+places = { git = "https://github.com/CanalTP/mimirsbrunn.git", branch = "bulk-backoff" }
 
 [dev-dependencies]
 cosmogony = "0.11"

--- a/config/elasticsearch/default.toml
+++ b/config/elasticsearch/default.toml
@@ -29,6 +29,14 @@
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-forcemerge.html
   enabled = true
 
+  # Timeout in milliseconds for the forcemerge operation
+  timeout = 10_000 # 10s
+
+  # Allow the forcemerge query to timeout, which would only result in a
+  # warning. Note that the forcemerge operation will still continue to be
+  # performed in the background anyway.
+  allow_timeout = true
+
   # Number of segments to merge to.
   max_number_segments = 1
 

--- a/config/elasticsearch/default.toml
+++ b/config/elasticsearch/default.toml
@@ -31,3 +31,12 @@
 
   # Number of segments to merge to.
   max_number_segments = 1
+
+# Setup a backoff to wait after a bulk operation fail and retry the operation,
+# each successive retry will wait twice as long as the previous one.
+[elasticsearch.bulk_backoff]
+  # Number of retries after the first failure (set 0 to never retry)
+  retry = 6
+
+  # Waiting time in milliseconds after the first failure
+  wait = 1000

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,7 @@ struct Args {
 }
 
 pub async fn run<S: DeserializeOwned, R: Future>(f: impl FnOnce(S) -> R) -> R::Output {
+    let _log_guard = logger_init().expect("could not init logger");
     let args = Args::from_args();
 
     let raw_config = config_from(
@@ -36,13 +37,6 @@ pub async fn run<S: DeserializeOwned, R: Future>(f: impl FnOnce(S) -> R) -> R::O
         args.settings,
     )
     .expect("could not build fafnir config");
-
-    let settings: S = raw_config
-        .clone()
-        .try_into()
-        .expect("invalid fafnir config");
-
-    let _log_guard = logger_init().expect("could not init logger");
 
     info!(
         "Full configuration:\n{}",
@@ -55,5 +49,6 @@ pub async fn run<S: DeserializeOwned, R: Future>(f: impl FnOnce(S) -> R) -> R::O
         .expect("could not serialize config"),
     );
 
+    let settings: S = raw_config.try_into().expect("invalid fafnir config");
     f(settings).await
 }


### PR DESCRIPTION
This should help fine tuning how we load the elasticsearch with much less risk of drowning it with way too much load. The same change will have to be made on mimir's side for bulk insertions though.

Also, I didn't notice but I had some clippy lints fixes applied locally :sweat_smile: 