### PR TITLE
introduce production profile for heavy linker optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ cosmogony = "0.11"
 serde_derive = "1"
 approx = "0.5.0"
 
-[profile.release]
+[profile.production]
+inherits = "release"
 lto = "fat"
 codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ COPY . ./
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/srv/fafnir/target        \
-    cargo build --release
+    cargo build --profile production
 
 # Move binary out of cache
 RUN mkdir bin
 RUN --mount=type=cache,target=/srv/fafnir/target             \
-    cp /srv/fafnir/target/release/openmaptiles2mimir bin/ && \
-    cp /srv/fafnir/target/release/tripadvisor2mimir bin/
+    cp /srv/fafnir/target/production/openmaptiles2mimir bin/ && \
+    cp /srv/fafnir/target/production/tripadvisor2mimir bin/
 
 
 FROM debian:buster-slim


### PR DESCRIPTION
Moves time consuming link time optimization to a new "production" profile to speedup the default release profile.

Inspired from https://github.com/osm-without-borders/cosmogony/blob/master/Dockerfile. This helped me save some time while doing some profiling in local.