### PR TITLE
Should do one request for all document updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "2.6.0"
-source = "git+https://github.com/remi-dupre/mimirsbrunn.git?branch=dot-key-updates#06c4934c735fafe98067ed6856b723862797c62a"
+source = "git+https://github.com/remi-dupre/mimirsbrunn.git?rev=13861dcabfba68d94a3cbc92d3b77262e1a8a7b6#13861dcabfba68d94a3cbc92d3b77262e1a8a7b6"
 dependencies = [
  "config",
  "serde",
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "mimir"
 version = "2.6.0"
-source = "git+https://github.com/remi-dupre/mimirsbrunn.git?branch=dot-key-updates#06c4934c735fafe98067ed6856b723862797c62a"
+source = "git+https://github.com/remi-dupre/mimirsbrunn.git?rev=13861dcabfba68d94a3cbc92d3b77262e1a8a7b6#13861dcabfba68d94a3cbc92d3b77262e1a8a7b6"
 dependencies = [
  "async-trait",
  "bollard",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "mimirsbrunn"
 version = "2.6.0"
-source = "git+https://github.com/remi-dupre/mimirsbrunn.git?branch=dot-key-updates#06c4934c735fafe98067ed6856b723862797c62a"
+source = "git+https://github.com/remi-dupre/mimirsbrunn.git?rev=13861dcabfba68d94a3cbc92d3b77262e1a8a7b6#13861dcabfba68d94a3cbc92d3b77262e1a8a7b6"
 dependencies = [
  "address-formatter",
  "anyhow",
@@ -2006,7 +2006,7 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 [[package]]
 name = "places"
 version = "2.6.0"
-source = "git+https://github.com/remi-dupre/mimirsbrunn.git?branch=dot-key-updates#06c4934c735fafe98067ed6856b723862797c62a"
+source = "git+https://github.com/remi-dupre/mimirsbrunn.git?rev=13861dcabfba68d94a3cbc92d3b77262e1a8a7b6#13861dcabfba68d94a3cbc92d3b77262e1a8a7b6"
 dependencies = [
  "chrono-tz",
  "common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ tracing-futures = "0.2"
 tracing = { version = "0.1", default_features = false, features = ["release_max_level_info"] }
 url = { version = "2", features = ["serde"] }
 
-mimirsbrunn = { git = "https://github.com/remi-dupre/mimirsbrunn.git", branch = "dot-key-updates" }
-mimir = { git = "https://github.com/remi-dupre/mimirsbrunn.git", branch = "dot-key-updates" }
-places = { git = "https://github.com/remi-dupre/mimirsbrunn.git", branch = "dot-key-updates" }
+mimirsbrunn = { git = "https://github.com/remi-dupre/mimirsbrunn.git", rev="13861dcabfba68d94a3cbc92d3b77262e1a8a7b6"}
+mimir = { git = "https://github.com/remi-dupre/mimirsbrunn.git", rev="13861dcabfba68d94a3cbc92d3b77262e1a8a7b6" }
+places = { git = "https://github.com/remi-dupre/mimirsbrunn.git", rev="13861dcabfba68d94a3cbc92d3b77262e1a8a7b6" }
 
 [dev-dependencies]
 cosmogony = "0.11"

--- a/src/bin/tripadvisor2mimir.rs
+++ b/src/bin/tripadvisor2mimir.rs
@@ -143,7 +143,7 @@ async fn load_and_index_tripadvisor(settings: Settings) {
                 )
             })
             .filter(|(ta_id, _)| future::ready(indexed_documents.contains(ta_id)))
-            .flat_map(|(ta_id, reviews)| {
+            .map(|(ta_id, reviews)| {
                 count_ok += 1;
                 let update_operations = reviews
                     .into_iter()
@@ -156,7 +156,7 @@ async fn load_and_index_tripadvisor(settings: Settings) {
                         }
                     })
                     .collect();
-                futures::stream::iter([(build_id(ta_id), update_operations)])
+                (build_id(ta_id), update_operations)
             });
 
         let index_generator = index_generator

--- a/src/bin/tripadvisor2mimir.rs
+++ b/src/bin/tripadvisor2mimir.rs
@@ -115,7 +115,7 @@ async fn load_and_index_tripadvisor(settings: Settings) {
                 };
 
                 count_ok += 1;
-                (build_id(ta_id), op)
+                (build_id(ta_id), vec![op])
             });
 
         let index_generator = index_generator
@@ -145,16 +145,18 @@ async fn load_and_index_tripadvisor(settings: Settings) {
             .filter(|(ta_id, _)| future::ready(indexed_documents.contains(ta_id)))
             .flat_map(|(ta_id, reviews)| {
                 count_ok += 1;
-                futures::stream::iter(reviews.into_iter().enumerate().map(
-                    move |(review_id, review)| {
+                let update_operations = reviews
+                    .into_iter()
+                    .enumerate()
+                    .map(|(review_id, review)| {
                         let ident = format!("properties.ta:reviews:{review_id}");
-                        let op = UpdateOperation::Set {
+                        UpdateOperation::Set {
                             ident,
                             value: review,
-                        };
-                        (build_id(ta_id), op)
-                    },
-                ))
+                        }
+                    })
+                    .collect();
+                futures::stream::iter([(build_id(ta_id), update_operations)])
             });
 
         let index_generator = index_generator


### PR DESCRIPTION
Change update strategy from `(id, [op1, op2, op3])` to `[(id, op1), (id, op2), (id, op3)]`